### PR TITLE
chore/deprecation-of-ioutil

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,5 +7,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ package postgrest
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -100,7 +100,7 @@ func (c *Client) Rpc(name string, count string, rpcBody interface{}) string {
 		return ""
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.ClientError = err
 		return ""

--- a/execute.go
+++ b/execute.go
@@ -2,7 +2,7 @@ package postgrest
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -21,7 +21,7 @@ func ExecuteHelper(client *Client, method string, body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	respbody, err := ioutil.ReadAll(resp.Body)
+	respbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small refactor that removes deprecated `io/ioutil` package and uses `io` package instead. 

## What is the current behavior?

Currently `client.go` and `execute.go` uses the deprecated package `io/ioutil`. Although `io/ioutil` will continue to work as expected, the go team encorages the usage of `io` and `os` packages as of go version `1.16`. More info can be found here: https://golang.org/doc/go1.16#ioutil
  
## What is the new behavior?

The behavior with `io.ReadAll` is the same as deprecated `ioutil.ReadAll`. 
## Additional context

No additional context 😅 