### PR TITLE
New execute method for json objects

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -54,6 +54,6 @@ func executeTo(client *Client, method string, body []byte) (interface{}, error) 
 
 	readableRes := bytes.NewBuffer(resp)
 
-	err = json.NewDecoder(readableRes).Decode(decodedBody)
+	err = json.NewDecoder(readableRes).Decode(&decodedBody)
 	return decodedBody, err
 }

--- a/execute.go
+++ b/execute.go
@@ -2,6 +2,7 @@ package postgrest
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 )
@@ -40,4 +41,19 @@ func executeString(client *Client, method string, body []byte) (string, error) {
 
 func execute(client *Client, method string, body []byte) ([]byte, error) {
 	return executeHelper(client, method, body)
+}
+
+func executeTo(client *Client, method string, body []byte) (interface{}, error) {
+	resp, err := executeHelper(client, method, body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var decodedBody interface{}
+
+	readableRes := bytes.NewBuffer(resp)
+
+	err = json.NewDecoder(readableRes).Decode(decodedBody)
+	return decodedBody, err
 }

--- a/execute.go
+++ b/execute.go
@@ -43,17 +43,15 @@ func execute(client *Client, method string, body []byte) ([]byte, error) {
 	return executeHelper(client, method, body)
 }
 
-func executeTo(client *Client, method string, body []byte) (interface{}, error) {
+func executeTo(client *Client, method string, body []byte, to interface{}) error {
 	resp, err := executeHelper(client, method, body)
 
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	var decodedBody interface{}
 
 	readableRes := bytes.NewBuffer(resp)
 
-	err = json.NewDecoder(readableRes).Decode(&decodedBody)
-	return decodedBody, err
+	err = json.NewDecoder(readableRes).Decode(&to)
+	return err
 }

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -21,8 +21,8 @@ func (f *FilterBuilder) Execute() ([]byte, error) {
 	return execute(f.client, f.method, f.body)
 }
 
-func (f *FilterBuilder) ExecuteTo() (interface{}, error) {
-	return executeTo(f.client, f.method, f.body)
+func (f *FilterBuilder) ExecuteTo(to interface{}) error {
+	return executeTo(f.client, f.method, f.body, to)
 }
 
 var filterOperators = []string{"eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts", "phfts", "wfts"}

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -21,6 +21,10 @@ func (f *FilterBuilder) Execute() ([]byte, error) {
 	return execute(f.client, f.method, f.body)
 }
 
+func (f *FilterBuilder) ExecuteTo() (interface{}, error) {
+	return executeTo(f.client, f.method, f.body)
+}
+
 var filterOperators = []string{"eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts", "phfts", "wfts"}
 
 func isOperator(value string) bool {

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -19,8 +19,8 @@ func (q *QueryBuilder) Execute() ([]byte, error) {
 	return execute(q.client, q.method, q.body)
 }
 
-func (q *QueryBuilder) ExecuteTo() (interface{}, error) {
-	return executeTo(q.client, q.method, q.body)
+func (q *QueryBuilder) ExecuteTo(to interface{}) error {
+	return executeTo(q.client, q.method, q.body, to)
 }
 
 func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -19,6 +19,10 @@ func (q *QueryBuilder) Execute() ([]byte, error) {
 	return execute(q.client, q.method, q.body)
 }
 
+func (q *QueryBuilder) ExecuteTo() (interface{}, error) {
+	return executeTo(q.client, q.method, q.body)
+}
+
 func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {
 	if head {
 		q.method = "HEAD"

--- a/transformbuilder.go
+++ b/transformbuilder.go
@@ -16,8 +16,8 @@ func (t *TransformBuilder) Execute() ([]byte, error) {
 	return execute(t.client, t.method, t.body)
 }
 
-func (t *TransformBuilder) ExecuteTo() (interface{}, error) {
-	return executeTo(t.client, t.method, t.body)
+func (t *TransformBuilder) ExecuteTo(to interface{}) error {
+	return executeTo(t.client, t.method, t.body, to)
 }
 
 func (t *TransformBuilder) Limit(count int, foreignTable string) *TransformBuilder {

--- a/transformbuilder.go
+++ b/transformbuilder.go
@@ -16,6 +16,10 @@ func (t *TransformBuilder) Execute() ([]byte, error) {
 	return execute(t.client, t.method, t.body)
 }
 
+func (t *TransformBuilder) ExecuteTo() (interface{}, error) {
+	return executeTo(t.client, t.method, t.body)
+}
+
 func (t *TransformBuilder) Limit(count int, foreignTable string) *TransformBuilder {
 
 	if foreignTable != "" {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR implements a new `executeTo` method which automatically parses the response into a json object as described in #7 

## What is the current behavior?

#7 

## What is the new behavior?

An `ExecuteTo` method was added to the structs as described which directly parses the response body into an `interface{}`

## Additional context

I tried to implement the changes described in the issue but was not sure regarding the requriements. I currently implemented the functions as requested with the return value of an `(interface{}, error)` for the `ExecuteTo` functions.

I also thought about changing the function to `ExecuteTo(target interface{}) error` which enables the user to give a custom struct or map from outside. Then instead of creating a new object inside the `executeTo` function, this target value is used to parse the response body into. I would be open to implement this function as well - maybe under a different name like `ExecuteInto`

As this is my first contribution, i hope i didn't miss something or did something wrong, if so please let me know so i can fix it!
