### PR TITLE
In cases of non 20x responses, return an error from Execute()

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -3,9 +3,20 @@ package postgrest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 )
+
+// ExecuteErrorResponse is the error response format from postgrest. We really
+// only use Code and Message, but we'll keep it as a struct for now.
+
+type ExecuteErrorResponse struct {
+	Hint    string `json:"hint"`
+	Details string `json:"details"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
 
 func executeHelper(client *Client, method string, body []byte) ([]byte, error) {
 	if client.ClientError != nil {
@@ -17,14 +28,24 @@ func executeHelper(client *Client, method string, body []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	resp, err := client.session.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	respbody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	respbody, rerr := io.ReadAll(resp.Body)
+	if rerr != nil {
+		return nil, rerr
+	}
+
+	// If we didnt get 20x response, unmarshal the error body to be able to format
+	// an informative error message. Mayb this should be >= 400, since I doubt redirect
+	// errors are returned.. but to be safe
+	if resp.StatusCode >= 300 {
+		var errmsg *ExecuteErrorResponse
+		json.Unmarshal(respbody, &errmsg)
+		return nil, fmt.Errorf("(%s) %s", errmsg.Code, errmsg.Message)
 	}
 
 	err = resp.Body.Close()

--- a/execute.go
+++ b/execute.go
@@ -44,7 +44,10 @@ func executeHelper(client *Client, method string, body []byte) ([]byte, error) {
 	// errors are returned.. but to be safe
 	if resp.StatusCode >= 300 {
 		var errmsg *ExecuteErrorResponse
-		json.Unmarshal(respbody, &errmsg)
+		err := json.Unmarshal(respbody, &errmsg)
+		if err != nil {
+			return nil, err
+		}
 		return nil, fmt.Errorf("(%s) %s", errmsg.Code, errmsg.Message)
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allows Execute() to actually return an error if a non 20x response is received from supabase.

## What is the current behavior?

Currently, if an error is received, Execute() return a nil error and the response from supabase. This then requires the user to determine if an error occurred by the contents of the response bytes

ex:
```
resp, err := client.From("sometable").Insert(document, false, "", "", "").Execute()
// error will always be nil with current behavior, if (for example) sometable doesnt exist
if err != nil {
  // nothing to handle
}
```

## What is the new behavior?

```
resp, err := client.From("sometable").Insert(document, false, "", "", "").Execute()
// error will not be nil if any non 20x error is returned from supabase
if err != nil {
  // print, or log, or return etc
  fmt.Printf("ERROR: %s\n", err)
}
```

## Additional context
I made two decisions that could be changed. The first was to include `Hint` and `Details` in the response struct, even though they are not used. The second was do do >= 300 vs 400 on the error check,
