### PR TITLE
feat: avoid mutating shared state

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ func NewClient(rawURL, schema string, headers map[string]string) *Client {
 	}
 
 	t := transport{
-		params:  url.Values{},
 		header:  http.Header{},
 		baseURL: *baseURL,
 	}
@@ -112,14 +111,16 @@ func (c *Client) Rpc(name string, count string, rpcBody interface{}) string {
 }
 
 type transport struct {
-	params  url.Values
 	header  http.Header
 	baseURL url.URL
 }
 
 func (t transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header = t.header
+	for headerName, values := range t.header {
+		for _, val := range values {
+			req.Header.Add(headerName, val)
+		}
+	}
 	req.URL = t.baseURL.ResolveReference(req.URL)
-	req.URL.RawQuery = t.params.Encode()
 	return http.DefaultTransport.RoundTrip(req)
 }

--- a/client.go
+++ b/client.go
@@ -62,12 +62,10 @@ func (c *Client) ChangeSchema(schema string) *Client {
 }
 
 func (c *Client) From(table string) *QueryBuilder {
-	c.clientTransport.baseURL.Path += table
-	return &QueryBuilder{client: c}
+	return &QueryBuilder{client: c, tableName: table, headers: map[string]string{}, params: map[string]string{}}
 }
 
 func (c *Client) Rpc(name string, count string, rpcBody interface{}) string {
-
 	// Get body if exist
 	var byteBody []byte = nil
 	if rpcBody != nil {
@@ -87,11 +85,7 @@ func (c *Client) Rpc(name string, count string, rpcBody interface{}) string {
 	}
 
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
-		if c.clientTransport.header.Get("Prefer") == "" {
-			c.clientTransport.header.Set("Prefer", "count="+count)
-		} else {
-			c.clientTransport.header.Set("Prefer", c.clientTransport.header.Get("Prefer")+",count="+count)
-		}
+		req.Header.Add("Prefer", "count=" + count)
 	}
 
 	resp, err := c.session.Do(req)

--- a/client.go
+++ b/client.go
@@ -84,7 +84,7 @@ func (c *Client) Rpc(name string, count string, rpcBody interface{}) string {
 	}
 
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
-		req.Header.Add("Prefer", "count=" + count)
+		req.Header.Add("Prefer", "count="+count)
 	}
 
 	resp, err := c.session.Do(req)

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -137,12 +137,12 @@ func (f *FilterBuilder) In(column string, values []string) *FilterBuilder {
 }
 
 func (f *FilterBuilder) Contains(column string, value []string) *FilterBuilder {
-	f.params[column] = "cs."+strings.Join(value, ",")
+	f.params[column] = "cs." + strings.Join(value, ",")
 	return f
 }
 
 func (f *FilterBuilder) ContainedBy(column string, value []string) *FilterBuilder {
-	f.params[column] = "cd."+strings.Join(value, ",")
+	f.params[column] = "cd." + strings.Join(value, ",")
 	return f
 }
 
@@ -151,7 +151,7 @@ func (f *FilterBuilder) ContainsObject(column string, value interface{}) *Filter
 	if err != nil {
 		f.client.ClientError = err
 	}
-	f.params[column] = "cs."+string(sum)
+	f.params[column] = "cs." + string(sum)
 	return f
 }
 
@@ -160,7 +160,7 @@ func (f *FilterBuilder) ContainedByObject(column string, value interface{}) *Fil
 	if err != nil {
 		f.client.ClientError = err
 	}
-	f.params[column] = "cs."+string(sum)
+	f.params[column] = "cs." + string(sum)
 	return f
 }
 
@@ -211,6 +211,6 @@ func (f *FilterBuilder) TextSearch(column, userQuery, config, tsType string) *Fi
 	if config != "" {
 		configPart = fmt.Sprintf("(%s)", config)
 	}
-	f.params[column] = typePart+"fts"+configPart+"."+userQuery
+	f.params[column] = typePart + "fts" + configPart + "." + userQuery
 	return f
 }

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -9,21 +9,24 @@ import (
 )
 
 type FilterBuilder struct {
-	client *Client
-	method string
-	body   []byte
+	client    *Client
+	method    string
+	body      []byte
+	tableName string
+	headers   map[string]string
+	params    map[string]string
 }
 
 func (f *FilterBuilder) ExecuteString() (string, error) {
-	return executeString(f.client, f.method, f.body)
+	return executeString(f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
 func (f *FilterBuilder) Execute() ([]byte, error) {
-	return execute(f.client, f.method, f.body)
+	return execute(f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
 func (f *FilterBuilder) ExecuteTo(to interface{}) error {
-	return executeTo(f.client, f.method, f.body, to)
+	return executeTo(f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
 }
 
 var filterOperators = []string{"eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts", "phfts", "wfts"}
@@ -42,15 +45,15 @@ func (f *FilterBuilder) Filter(column, operator, value string) *FilterBuilder {
 		f.client.ClientError = fmt.Errorf("invalid filter operator")
 		return f
 	}
-	f.client.clientTransport.params.Add(column, operator+"."+value)
+	f.params[column] = fmt.Sprintf("%s.%s", operator, value)
 	return f
 }
 
 func (f *FilterBuilder) Or(filters, foreignTable string) *FilterBuilder {
 	if foreignTable != "" {
-		f.client.clientTransport.params.Add(foreignTable+".or", fmt.Sprintf("(%s)", filters))
+		f.params[foreignTable+".or"] = fmt.Sprintf("(%s)", filters)
 	} else {
-		f.client.clientTransport.params.Add("or", fmt.Sprintf("(%s)", filters))
+		f.params[foreignTable+"or"] = fmt.Sprintf("(%s)", filters)
 	}
 	return f
 }
@@ -59,59 +62,59 @@ func (f *FilterBuilder) Not(column, operator, value string) *FilterBuilder {
 	if !isOperator(operator) {
 		return f
 	}
-	f.client.clientTransport.params.Add(column, "not."+operator+"."+value)
+	f.params[column] = fmt.Sprintf("not.%s.%s", operator, value)
 	return f
 }
 
 func (f *FilterBuilder) Match(userQuery map[string]string) *FilterBuilder {
 	for key, value := range userQuery {
-		f.client.clientTransport.params.Add(key, "eq."+value)
+		f.params[key] = "eq." + value
 	}
 	return f
 }
 
 func (f *FilterBuilder) Eq(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "eq."+value)
+	f.params[column] = "eq." + value
 	return f
 }
 
 func (f *FilterBuilder) Neq(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "neq."+value)
+	f.params[column] = "neq." + value
 	return f
 }
 
 func (f *FilterBuilder) Gt(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "gt."+value)
+	f.params[column] = "gt." + value
 	return f
 }
 
 func (f *FilterBuilder) Gte(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "gte."+value)
+	f.params[column] = "gte." + value
 	return f
 }
 
 func (f *FilterBuilder) Lt(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "lt."+value)
+	f.params[column] = "lt." + value
 	return f
 }
 
 func (f *FilterBuilder) Lte(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "lte."+value)
+	f.params[column] = "lte." + value
 	return f
 }
 
 func (f *FilterBuilder) Like(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "like."+value)
+	f.params[column] = "like." + value
 	return f
 }
 
 func (f *FilterBuilder) Ilike(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "ilike."+value)
+	f.params[column] = "ilike." + value
 	return f
 }
 
 func (f *FilterBuilder) Is(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "is."+value)
+	f.params[column] = "is." + value
 	return f
 }
 
@@ -129,17 +132,17 @@ func (f *FilterBuilder) In(column string, values []string) *FilterBuilder {
 			cleanedValues = append(cleanedValues, value)
 		}
 	}
-	f.client.clientTransport.params.Add(column, fmt.Sprintf("in.(%s)", strings.Join(cleanedValues, ",")))
+	f.params[column] = fmt.Sprintf("in.(%s)", strings.Join(cleanedValues, ","))
 	return f
 }
 
 func (f *FilterBuilder) Contains(column string, value []string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "cs."+strings.Join(value, ","))
+	f.params[column] = "cs."+strings.Join(value, ",")
 	return f
 }
 
 func (f *FilterBuilder) ContainedBy(column string, value []string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "cd."+strings.Join(value, ","))
+	f.params[column] = "cd."+strings.Join(value, ",")
 	return f
 }
 
@@ -148,7 +151,7 @@ func (f *FilterBuilder) ContainsObject(column string, value interface{}) *Filter
 	if err != nil {
 		f.client.ClientError = err
 	}
-	f.client.clientTransport.params.Add(column, "cs."+string(sum))
+	f.params[column] = "cs."+string(sum)
 	return f
 }
 
@@ -157,37 +160,37 @@ func (f *FilterBuilder) ContainedByObject(column string, value interface{}) *Fil
 	if err != nil {
 		f.client.ClientError = err
 	}
-	f.client.clientTransport.params.Add(column, "cs."+string(sum))
+	f.params[column] = "cs."+string(sum)
 	return f
 }
 
 func (f *FilterBuilder) RangeLt(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "sl."+value)
+	f.params[column] = "sl." + value
 	return f
 }
 
 func (f *FilterBuilder) RangeGt(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "sr."+value)
+	f.params[column] = "sr." + value
 	return f
 }
 
 func (f *FilterBuilder) RangeGte(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "nxl."+value)
+	f.params[column] = "nxl." + value
 	return f
 }
 
 func (f *FilterBuilder) RangeLte(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "nxr."+value)
+	f.params[column] = "nxr." + value
 	return f
 }
 
 func (f *FilterBuilder) RangeAdjacent(column, value string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "adj."+value)
+	f.params[column] = "adj." + value
 	return f
 }
 
 func (f *FilterBuilder) Overlaps(column string, value []string) *FilterBuilder {
-	f.client.clientTransport.params.Add(column, "ov."+strings.Join(value, ","))
+	f.params[column] = "ov." + strings.Join(value, ",")
 	return f
 }
 
@@ -208,6 +211,6 @@ func (f *FilterBuilder) TextSearch(column, userQuery, config, tsType string) *Fi
 	if config != "" {
 		configPart = fmt.Sprintf("(%s)", config)
 	}
-	f.client.clientTransport.params.Add(column, typePart+"fts"+configPart+"."+userQuery)
+	f.params[column] = typePart+"fts"+configPart+"."+userQuery
 	return f
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -59,7 +59,7 @@ func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {
 		}
 		q.params["Prefer"] = count
 	}
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: q.headers, params: q.params}
 }
 
 func (q *QueryBuilder) Insert(value interface{}, upsert bool, onConflict, returning, count string) *FilterBuilder {
@@ -95,7 +95,7 @@ func (q *QueryBuilder) Insert(value interface{}, upsert bool, onConflict, return
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: q.headers, params: q.params}
 }
 func (q *QueryBuilder) Upsert(value interface{}, onConflict, returning, count string) *FilterBuilder {
 	q.method = "POST"
@@ -127,7 +127,7 @@ func (q *QueryBuilder) Upsert(value interface{}, onConflict, returning, count st
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: q.headers, params: q.params}
 }
 
 func (q *QueryBuilder) Delete(returning, count string) *FilterBuilder {
@@ -144,7 +144,7 @@ func (q *QueryBuilder) Delete(returning, count string) *FilterBuilder {
 		headerList = append(headerList, "count="+count)
 	}
 	q.headers["Prefer"] = strings.Join(headerList, ",")
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: q.headers, params: q.params}
 }
 
 func (q *QueryBuilder) Update(value interface{}, returning, count string) *FilterBuilder {
@@ -173,5 +173,5 @@ func (q *QueryBuilder) Update(value interface{}, returning, count string) *Filte
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: q.headers, params: q.params}
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -2,25 +2,29 @@ package postgrest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
 type QueryBuilder struct {
-	client *Client
-	method string
-	body   []byte
+	client    *Client
+	method    string
+	body      []byte
+	tableName string
+	headers   map[string]string
+	params    map[string]string
 }
 
 func (q *QueryBuilder) ExecuteString() (string, error) {
-	return executeString(q.client, q.method, q.body)
+	return executeString(q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
 func (q *QueryBuilder) Execute() ([]byte, error) {
-	return execute(q.client, q.method, q.body)
+	return execute(q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
 func (q *QueryBuilder) ExecuteTo(to interface{}) error {
-	return executeTo(q.client, q.method, q.body, to)
+	return executeTo(q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
 }
 
 func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {
@@ -31,7 +35,7 @@ func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {
 	}
 
 	if columns == "" {
-		q.client.clientTransport.params.Add("select", "*")
+		q.params["select"] = "*"
 	} else {
 		quoted := false
 		var resultArr = []string{}
@@ -45,24 +49,24 @@ func (q *QueryBuilder) Select(columns, count string, head bool) *FilterBuilder {
 			resultArr = append(resultArr, char)
 		}
 		result := strings.Join(resultArr, "")
-		q.client.clientTransport.params.Add("select", result)
+		q.params["select"] = result
 	}
 
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
-		if q.client.clientTransport.header.Get("Prefer") == "" {
-			q.client.clientTransport.header.Set("Prefer", "count="+count)
-		} else {
-			q.client.clientTransport.header.Set("Prefer", q.client.clientTransport.header.Get("Prefer")+",count="+count)
+		currentValue, ok := q.params["Prefer"]
+		if ok && currentValue != "" {
+			count = fmt.Sprintf("%s,count=%s", currentValue, count)
 		}
+		q.params["Prefer"] = count
 	}
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
 }
 
 func (q *QueryBuilder) Insert(value interface{}, upsert bool, onConflict, returning, count string) *FilterBuilder {
 	q.method = "POST"
 
 	if onConflict != "" && upsert {
-		q.client.clientTransport.params.Add("on_conflict", onConflict)
+		q.params["on_conflict"] = onConflict
 	}
 
 	headerList := []string{}
@@ -78,7 +82,7 @@ func (q *QueryBuilder) Insert(value interface{}, upsert bool, onConflict, return
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
 		headerList = append(headerList, "count="+count)
 	}
-	q.client.clientTransport.header.Set("Prefer", strings.Join(headerList, ","))
+	q.headers["Prefer"] = strings.Join(headerList, ",")
 
 	// Get body if exist
 	var byteBody []byte = nil
@@ -91,13 +95,13 @@ func (q *QueryBuilder) Insert(value interface{}, upsert bool, onConflict, return
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
 }
 func (q *QueryBuilder) Upsert(value interface{}, onConflict, returning, count string) *FilterBuilder {
 	q.method = "POST"
 
 	if onConflict != "" {
-		q.client.clientTransport.params.Add("on_conflict", onConflict)
+		q.params["on_conflict"] = onConflict
 	}
 
 	headerList := []string{"resolution=merge-duplicates"}
@@ -110,7 +114,7 @@ func (q *QueryBuilder) Upsert(value interface{}, onConflict, returning, count st
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
 		headerList = append(headerList, "count="+count)
 	}
-	q.client.clientTransport.header.Set("Prefer", strings.Join(headerList, ","))
+	q.headers["Prefer"] = strings.Join(headerList, ",")
 
 	// Get body if exist
 	var byteBody []byte = nil
@@ -123,7 +127,7 @@ func (q *QueryBuilder) Upsert(value interface{}, onConflict, returning, count st
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
 }
 
 func (q *QueryBuilder) Delete(returning, count string) *FilterBuilder {
@@ -139,8 +143,8 @@ func (q *QueryBuilder) Delete(returning, count string) *FilterBuilder {
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
 		headerList = append(headerList, "count="+count)
 	}
-	q.client.clientTransport.header.Set("Prefer", strings.Join(headerList, ","))
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body}
+	q.headers["Prefer"] = strings.Join(headerList, ",")
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
 }
 
 func (q *QueryBuilder) Update(value interface{}, returning, count string) *FilterBuilder {
@@ -156,7 +160,7 @@ func (q *QueryBuilder) Update(value interface{}, returning, count string) *Filte
 	if count != "" && (count == `exact` || count == `planned` || count == `estimated`) {
 		headerList = append(headerList, "count="+count)
 	}
-	q.client.clientTransport.header.Set("Prefer", strings.Join(headerList, ","))
+	q.headers["Prefer"] = strings.Join(headerList, ",")
 
 	// Get body if exist
 	var byteBody []byte = nil
@@ -169,5 +173,5 @@ func (q *QueryBuilder) Update(value interface{}, returning, count string) *Filte
 		byteBody = jsonBody
 	}
 	q.body = byteBody
-	return &FilterBuilder{client: q.client, method: q.method, body: q.body}
+	return &FilterBuilder{client: q.client, method: q.method, body: q.body, tableName: q.tableName, headers: map[string]string{}, params: map[string]string{}}
 }

--- a/transformbuilder.go
+++ b/transformbuilder.go
@@ -1,31 +1,35 @@
 package postgrest
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 type TransformBuilder struct {
-	client *Client
-	method string
-	body   []byte
+	client    *Client
+	method    string
+	body      []byte
+	headers   map[string]string
+	params    map[string]string
 }
 
 func (t *TransformBuilder) ExecuteString() (string, error) {
-	return executeString(t.client, t.method, t.body)
+	return executeString(t.client, t.method, t.body, []string{}, t.headers, t.params)
 }
 
 func (t *TransformBuilder) Execute() ([]byte, error) {
-	return execute(t.client, t.method, t.body)
+	return execute(t.client, t.method, t.body, []string{}, t.headers, t.params)
 }
 
 func (t *TransformBuilder) ExecuteTo(to interface{}) error {
-	return executeTo(t.client, t.method, t.body, to)
+	return executeTo(t.client, t.method, t.body, to, []string{}, t.headers, t.params)
 }
 
 func (t *TransformBuilder) Limit(count int, foreignTable string) *TransformBuilder {
-
 	if foreignTable != "" {
-		t.client.clientTransport.params.Add(foreignTable+".limit", fmt.Sprint(count))
+		t.params[foreignTable + ".limit"] = strconv.Itoa(count)
 	} else {
-		t.client.clientTransport.params.Add("limit", fmt.Sprint(count))
+		t.params["limit"] = strconv.Itoa(count)
 	}
 
 	return t
@@ -39,7 +43,7 @@ func (t *TransformBuilder) Order(column, foreignTable string, ascending, nullsFi
 		key = "order"
 	}
 
-	existingOrder := t.client.clientTransport.params.Get(key)
+	existingOrder, ok := t.params[key]
 
 	var ascendingString string
 	if ascending {
@@ -55,28 +59,27 @@ func (t *TransformBuilder) Order(column, foreignTable string, ascending, nullsFi
 		nullsString = "nullslast"
 	}
 
-	if existingOrder != "" {
-		t.client.clientTransport.params.Set(key, existingOrder+","+column+"."+ascendingString+"."+nullsString)
+	if ok && existingOrder != "" {
+		t.params[key] = fmt.Sprintf("%s,%s.%s.%s", existingOrder, column, ascendingString, nullsString)
 	} else {
-		t.client.clientTransport.params.Add(key, column+"."+ascendingString+"."+nullsString)
+		t.params[key] = fmt.Sprintf("%s.%s.%s", column, ascendingString, nullsString)
 	}
 
 	return t
 }
 
 func (t *TransformBuilder) Range(from, to int, foreignTable string) *TransformBuilder {
-
 	if foreignTable != "" {
-		t.client.clientTransport.params.Add(foreignTable+".offset", fmt.Sprint(from))
-		t.client.clientTransport.params.Add(foreignTable+".limit", fmt.Sprint(to-from+1))
+		t.params[foreignTable + ".offset"] = strconv.Itoa(from)
+		t.params[foreignTable + ".limit"] = strconv.Itoa(to - from + 1)
 	} else {
-		t.client.clientTransport.params.Add("offset", fmt.Sprint(from))
-		t.client.clientTransport.params.Add("limit", fmt.Sprint(to-from+1))
+		t.params["offset"] = strconv.Itoa(from)
+		t.params["limit"] = strconv.Itoa(to - from + 1)
 	}
 	return t
 }
 
 func (t *TransformBuilder) Single() *TransformBuilder {
-	t.client.clientTransport.header.Set("Accept", "application/vnd.pgrst.object+json")
+	t.headers["Accept"] = "application/vnd.pgrst.object+json"
 	return t
 }

--- a/transformbuilder.go
+++ b/transformbuilder.go
@@ -6,11 +6,11 @@ import (
 )
 
 type TransformBuilder struct {
-	client    *Client
-	method    string
-	body      []byte
-	headers   map[string]string
-	params    map[string]string
+	client  *Client
+	method  string
+	body    []byte
+	headers map[string]string
+	params  map[string]string
 }
 
 func (t *TransformBuilder) ExecuteString() (string, error) {
@@ -27,7 +27,7 @@ func (t *TransformBuilder) ExecuteTo(to interface{}) error {
 
 func (t *TransformBuilder) Limit(count int, foreignTable string) *TransformBuilder {
 	if foreignTable != "" {
-		t.params[foreignTable + ".limit"] = strconv.Itoa(count)
+		t.params[foreignTable+".limit"] = strconv.Itoa(count)
 	} else {
 		t.params["limit"] = strconv.Itoa(count)
 	}
@@ -70,8 +70,8 @@ func (t *TransformBuilder) Order(column, foreignTable string, ascending, nullsFi
 
 func (t *TransformBuilder) Range(from, to int, foreignTable string) *TransformBuilder {
 	if foreignTable != "" {
-		t.params[foreignTable + ".offset"] = strconv.Itoa(from)
-		t.params[foreignTable + ".limit"] = strconv.Itoa(to - from + 1)
+		t.params[foreignTable+".offset"] = strconv.Itoa(from)
+		t.params[foreignTable+".limit"] = strconv.Itoa(to - from + 1)
 	} else {
 		t.params["offset"] = strconv.Itoa(from)
 		t.params["limit"] = strconv.Itoa(to - from + 1)


### PR DESCRIPTION
Instead of mutating the shared client object when dealing with table names, headers, and param fields, we instead push them down to the transport layer and have it collate them into a fresh request object instead. This allows re-use of the Supabase client for multiple requests.

Fixes #12 