### PR TITLE
fix: add error handling for json.Unmarshal and json.Marshal calls

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -262,7 +262,9 @@ func (b *Builder[T]) Execute(ctx context.Context) (*PostgrestResponse[T], error)
 				response.Data = any(strData).(T)
 			} else {
 				// If T is not string, try to unmarshal normally
-				json.Unmarshal(bodyBytes, &response.Data)
+				if err := json.Unmarshal(bodyBytes, &response.Data); err != nil {
+					return nil, fmt.Errorf("error unmarshaling response: %w", err)
+				}
 			}
 		} else if len(bodyBytes) > 0 {
 			acceptHeader := b.headers.Get("Accept")
@@ -305,18 +307,27 @@ func (b *Builder[T]) Execute(ctx context.Context) (*PostgrestResponse[T], error)
 						return response, nil
 					} else if len(arr) == 1 {
 						// Unmarshal single item
-						itemBytes, _ := json.Marshal(arr[0])
-						json.Unmarshal(itemBytes, &response.Data)
+						itemBytes, err := json.Marshal(arr[0])
+						if err != nil {
+							return nil, fmt.Errorf("error marshaling single item: %w", err)
+						}
+						if err := json.Unmarshal(itemBytes, &response.Data); err != nil {
+							return nil, fmt.Errorf("error unmarshaling single item: %w", err)
+						}
 					} else {
 						// Empty array, return null equivalent
 						response.Data = *new(T)
 					}
 				} else {
 					// Not an array, unmarshal directly
-					json.Unmarshal(bodyBytes, &response.Data)
+					if err := json.Unmarshal(bodyBytes, &response.Data); err != nil {
+						return nil, fmt.Errorf("error unmarshaling response: %w", err)
+					}
 				}
 			} else {
-				json.Unmarshal(bodyBytes, &response.Data)
+				if err := json.Unmarshal(bodyBytes, &response.Data); err != nil {
+					return nil, fmt.Errorf("error unmarshaling response: %w", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Description**
Fix golangci-lint errcheck errors by adding proper error handling for `json.Unmarshal` and `json.Marshal` calls in `builder.go`.

**Changes**
- Added error checking for `json.Unmarshal` at line 265 (CSV/plan text fallback case)
- Added error checking for `json.Marshal` and `json.Unmarshal` at lines 310-315 (maybeSingle single item case)
- Added error checking for `json.Unmarshal` at line 323 (maybeSingle non-array case)
- Added error checking for `json.Unmarshal` at line 328 (default case)

All errors are now properly handled by returning wrapped errors with clear context messages.

**Related Issues**
Fixes golangci-lint errcheck violations:
- `builder.go:265:19: Error return value of json.Unmarshal is not checked`
- `builder.go:309:21: Error return value of json.Unmarshal is not checked`
- `builder.go:316:20: Error return value of json.Unmarshal is not checked`