### PR TITLE
refactor: eliminate empty else block flagged by staticcheck

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -260,10 +260,6 @@ func (b *Builder[T]) Execute(ctx context.Context) (*PostgrestResponse[T], error)
 			var zeroT T
 			if _, ok := any(zeroT).(string); ok {
 				response.Data = any(strData).(T)
-			} else {
-				// If T is not string, for plan text we can't unmarshal as JSON
-				// Just leave Data as zero value - this is expected behavior for non-string types
-				// The response body is available as plain text but can't be unmarshaled into non-string T
 			}
 		} else if len(bodyBytes) > 0 {
 			acceptHeader := b.headers.Get("Accept")


### PR DESCRIPTION
This pull request removes an empty `else` block in `response/builder.go` that was causing the following Staticcheck warning:
The `else` block contained only comments, which Staticcheck treats as an empty branch. Removing it improves code clarity and resolves the lint issue without altering the program’s behavior.

## Changes

* Removed unnecessary empty `else` block.
* Improved control flow to follow idiomatic Go practices.
* Ensured the file passes Staticcheck without warnings.

## Reasoning

* The empty branch had no functional purpose.
* Staticcheck flagged it as a code smell and potential issue.
* Removing it makes the code cleaner and more consistent with Go style guidelines.

## Impact

* No behavior changes to the application.
* Cleaner and more maintainable code.
* Resolves linting errors that may affect CI pipelines.

## Testing

* Existing unit tests have been run and passed.