### PR TITLE
feat: add RpcWithContext for context-aware RPC calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -220,16 +220,27 @@ func (c *Client) Rpc(fn string, args interface{}, opts *RpcOptions) *FilterBuild
 // RpcWithError executes a Postgres function (a.k.a., Remote Procedure Call), given the
 // function name and, optionally, a body, returning the result as a string.
 func (c *Client) RpcWithError(name string, count string, rpcBody interface{}) (string, error) {
+	return c.RpcWithContext(context.Background(), name, count, rpcBody)
+}
+
+// RpcWithContext executes a Postgres function (RPC) with the given context.
+func (c *Client) RpcWithContext(
+	ctx context.Context,
+	name string,
+	count string,
+	rpcBody interface{},
+) (string, error) {
 	opts := &RpcOptions{Count: count}
 	filterBuilder := c.Rpc(name, rpcBody, opts)
-	response, err := filterBuilder.Execute(context.Background())
+
+	response, err := filterBuilder.Execute(ctx)
 	if err != nil {
 		return "", err
 	}
 	if response.Error != nil {
 		return "", response.Error
 	}
-	// Convert response.Data to string
+
 	dataBytes, _ := json.Marshal(response.Data)
 	return string(dataBytes), nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -128,3 +128,16 @@ func TestClient_RpcWithError(t *testing.T) {
 		assert.NotEmpty(t, result)
 	}
 }
+
+func TestClient_RpcWithContext_Canceled(t *testing.T) {
+	c := createClient(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	_, err := c.RpcWithContext(ctx, "test_function", "", map[string]interface{}{
+		"a": 1,
+	})
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

RPC calls do not allow passing a `context.Context`, so callers cannot set timeouts, deadlines, or cancel in-flight RPC requests.
Related issue: [#63](https://github.com/supabase-community/postgrest-go/issues/63)

## What is the new behavior?

Adds a context-aware RPC execution method (`RpcWithContext`) that allows callers to pass a context for cancellation and timeouts. Existing `RpcWithError` behavior is preserved by defaulting to `context.Background()`.

## Additional context

This follows the same pattern introduced in [#49](https://github.com/supabase-community/postgrest-go/pull/49) for query execution. Includes a test to ensure canceled contexts fail immediately.
