### PR TITLE
docs: clarify README Quick Start for v0.0.12 vs main API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,54 @@ Full documentation can be found [here](https://pkg.go.dev/github.com/supabase-co
 go get github.com/supabase-community/postgrest-go
 ```
 
+## Version compatibility
+
+`go get` without a version installs the latest **tagged release** (currently **v0.0.12**). The `main` branch has a newer API with generics, structured responses, and context-aware `Execute` methods.
+
+| Install command | API |
+| --- | --- |
+| `go get github.com/supabase-community/postgrest-go` | **v0.0.12** — `Select(columns, count, head)`, `Execute()` returns `([]byte, int64, error)` |
+| `go get github.com/supabase-community/postgrest-go@main` | **main** — `Select(columns, opts)`, `Execute(ctx)` returns `*PostgrestResponse` |
+
+The examples below (except [Basic usage v0.0.12](#basic-usage-v012)) require the **main** branch:
+
+```bash
+go get github.com/supabase-community/postgrest-go@main
+```
+
 ## Quick Start
 
-### Basic Usage
+### Basic usage (v0.0.12) {#basic-usage-v012}
+
+If you installed the default release tag, use this API:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/supabase-community/postgrest-go"
+)
+
+func main() {
+	client := postgrest.NewClient("http://localhost:3000/rest/v1", "public", nil)
+	if client.ClientError != nil {
+		panic(client.ClientError)
+	}
+
+	data, count, err := client.From("users").Select("*", "", false).Execute()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("count: %d\n", count)
+	fmt.Println(string(data))
+}
+```
+
+### Basic Usage (main branch)
 
 ```go
 package main


### PR DESCRIPTION
## Summary

Closes #86.

`go get` installs v0.0.12 by default, but the README examples use the newer main-branch API. This adds:

- A version compatibility table (v0.0.12 vs `@main`)
- A working **v0.0.12** basic usage example
- A note that the remaining Quick Start examples require `go get ...@main`

## Test plan

- [x] Verified v0.0.12 example matches `Select(columns, count, head)` and `Execute()` signatures from the v0.0.12 tag
- [x] Main-branch examples unchanged aside from section heading
