### PR TITLE
fix(ci): upgrade golangci-lint action for Go 1.25 modules

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.21
-      uses: actions/setup-go@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: "1.21.1"
+        go-version-file: go.mod
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     - name: Run Tests
       run: go test -v ./...
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: latest
+        version: v2.4.0
         args: --timeout=15m --out-format=line-number

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
       - name: Download dependencies
         run: go mod download
       - name: Test


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (CI / GitHub Actions workflow update).

## What is the current behavior?

The `golangci-lint` GitHub pipeline fails after upgrading the module to Go `1.25.0` with:
```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```
This happens because the workflow was using `golangci-lint-action@v6` (v1 linter path) while `go.mod` now targets Go `1.25.0` (introduced around dependency bump PR [#85](https://github.com/supabase-community/postgrest-go/pull/85)).

## What is the new behavior?

The CI workflows are aligned with `go.mod` and the lint job uses a Go `1.25`-compatible linter stack. This should prevent toolchain drift in the future.

## Additional context
